### PR TITLE
Fully-prototype get_fattime()

### DIFF
--- a/diskio.c
+++ b/diskio.c
@@ -144,7 +144,7 @@ DRESULT disk_ioctl (
 	return RES_PARERR;
 }
 
-DWORD get_fattime() 
+DWORD get_fattime(void)
 { 
 	struct tm tm;
 	time_t now = time(NULL);


### PR DESCRIPTION
```
[4/13] Building C object CMakeFiles/fusefatfs.dir/diskio.c.o /home/nabijaczleweli/uwu/fusefatfs/diskio.c:147:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  147 | DWORD get_fattime()
      |                  ^
      |                   void
1 warning generated.
[5/13] Building C object CMakeFiles/vufusefatfs.dir/diskio.c.o
/home/nabijaczleweli/uwu/fusefatfs/diskio.c:147:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  147 | DWORD get_fattime()
      |                  ^
      |                   void
1 warning generated.
```

Also your repository synopsis says "mount FAT file systems using FUSE anf VUOS/vufuse", should be "and"