### PR TITLE
Fix options listed in manual (program actually takes -o ro, -o rw, but -ro, -rw were listed). Fix manual spacing. Fix manual building on some restricted environments. Fix sytems -> systems typo in manual

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -13,7 +13,7 @@ none:
 % : %.md
 ifdef PANDOCOK
 ifeq (${PANDOCVEROK}, 1)
-		echo "${PANDOC} ${PANDOCVER} < ${PANDOCMINVER}. $@ can create font warnings with man/groff" >/dev/stderr >&2
+		echo "${PANDOC} ${PANDOCVER} < ${PANDOCMINVER}. $@ can create font warnings with man/groff" >&2
 endif
 # copy copyright notice
 		grep "^\.\\\\\"" $< > $@ || true
@@ -25,7 +25,7 @@ endif
 		$(PANDOC) -standalone -M title=${TITLE} -M section=${SECTION} -M header=${HEADER} -M footer=${PANDOC_ORG} -M "date=`date +\"%B %Y\"`" --to man $< >> $@
 # workaround for boldface rendering
 		sed -i -e 's/\\f\[CR\]/\\f\[CB\]/g' $@ || true
-		echo "$@ manpage updated" >/dev/stderr >&2
+		echo "$@ manpage updated" >&2
 else
-		echo "${PANDOC} is not available. Manpage $@ cannot be updated" >/dev/stderr >&2
+		echo "${PANDOC} is not available. Manpage $@ cannot be updated" >&2
 endif

--- a/man/fusefatfs.1
+++ b/man/fusefatfs.1
@@ -58,22 +58,22 @@ display a usage and options summary
 display version
 .SS fusefatfs specific options
 .TP
-\f[CB]\-ro\f[R]
+\f[CB]\-o ro\f[R]
 mount the file system in read\-only mode.
 .TP
-\f[CB]\-rw\f[R]
+\f[CB]\-o rw\f[R]
 mount the file system in read\-write mode only if also
-\f[CB]\-force\f[R] is present.
+\f[CB]\-o force\f[R] is present.
 Read\-write mounting can potentially manage the file system structure so
 an
 extra option is required to test the awareness fo the user.
 .TP
-\f[CB]\-force\f[R]
+\f[CB]\-o force\f[R]
 confirm the request of read\-write access.
 .TP
-\f[CB]\-rw+\f[R]
+\f[CB]\-o rw+\f[R]
 mount the file system in read\-write mode, a shortcut of
-\f[CB]\-rw \-force\f[R].
+\f[CB]\-o rw,force\f[R].
 .SS main FUSE mount options
 These options are not valid in VUOS/vufuse.
 .TP

--- a/man/fusefatfs.1
+++ b/man/fusefatfs.1
@@ -35,7 +35,7 @@ in a \f[CB]umvu\f[R] session:
 \f[I]disk_image\f[R] \f[I]mountpoint\f[R]
 .SH DESCRIPTION
 \f[CB]fusefatfs\f[R] mounts the file tree contained in
-\f[I]disk_image\f[R] on the directory \f[I]mountpoint\f[R] .
+\f[I]disk_image\f[R] on the directory \f[I]mountpoint\f[R].
 It supports FAT12, FAT16, FAT32 and exFAT formats.
 .PP
 \f[CB]vufusefatfs\f[R] is the VUOS/vufuse submodule of

--- a/man/fusefatfs.1
+++ b/man/fusefatfs.1
@@ -89,7 +89,7 @@ disable multi\-threaded operation
 \f[CB]fuse\f[R](8), \f[CB]umvu\f[R](1)
 .SH CREDITS
 \f[CB]fusefatfs\f[R] is based on the FAT file system module for embedded
-sytems \f[CB]fatfs\f[R] developed by ChaN:
+systems \f[CB]fatfs\f[R] developed by ChaN:
 \f[I]http://elm\-chan.org\f[R].
 .SH AUTHOR
 VirtualSquare.

--- a/man/fusefatfs.1.md
+++ b/man/fusefatfs.1.md
@@ -62,19 +62,19 @@ list.
 
 ### fusefatfs specific options
 
-  `-ro`
+  `-o ro`
 : mount the file system in read-only mode.
 
-  `-rw`
-: mount the file system in read-write mode only if also `-force` is present.
+  `-o rw`
+: mount the file system in read-write mode only if also `-o force` is present.
 : Read-write mounting can potentially manage the file system structure so an
 : extra option is required to test the awareness fo the user.
 
-  `-force`
+  `-o force`
 : confirm the request of read-write access.
 
-  `-rw+`
-: mount the file system in read-write mode, a shortcut of `-rw -force`.
+  `-o rw+`
+: mount the file system in read-write mode, a shortcut of `-o rw,force`.
 
 ### main FUSE mount options
 

--- a/man/fusefatfs.1.md
+++ b/man/fusefatfs.1.md
@@ -37,7 +37,7 @@ in a `umvu` session:
 
 # DESCRIPTION
 
-`fusefatfs` mounts the file tree contained in *disk_image* on the directory *mountpoint* .
+`fusefatfs` mounts the file tree contained in *disk_image* on the directory *mountpoint*.
 It supports FAT12, FAT16, FAT32 and exFAT formats.
 
 `vufusefatfs` is the VUOS/vufuse submodule of `fusefatfs`

--- a/man/fusefatfs.1.md
+++ b/man/fusefatfs.1.md
@@ -93,7 +93,7 @@ list.
 `fuse`(8), `umvu`(1)
 
 # CREDITS
-`fusefatfs` is based on the FAT file system module for embedded sytems `fatfs` 
+`fusefatfs` is based on the FAT file system module for embedded systems `fatfs`
 developed by ChaN:
 *http://elm-chan.org*.
 


### PR DESCRIPTION
Usage string says -o ro &c. correctly already